### PR TITLE
Fixing typo

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -132,7 +132,7 @@ $handler = GuzzleHttp\HandlerStack::create();
 $handler->push(Middleware::mapRequest(function (RequestInterface $request) {
     // Notice that we have to return a request object
     return $request->withHeader('X-Foo', 'Bar');
-});
+}));
 // Inject the handler into the client
 $client = new GuzzleHttp\Client(['handler' => $handler]);
 ```


### PR DESCRIPTION
There was a missing ')' on the middleware migration session.
